### PR TITLE
Add descriptions and maxLength to the exposure schema.

### DIFF
--- a/events/jsonschema/io.mintmetrics.mojito/mojito_exposure/jsonschema/1-0-0
+++ b/events/jsonschema/io.mintmetrics.mojito/mojito_exposure/jsonschema/1-0-0
@@ -1,5 +1,6 @@
 {
   "$schema" : "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description" : "These events are tracked approximately when users get assigned or bucketed into a test group. We use this to establish the time and group each user is in, so any future conversions can be attributed to the test.",
   "self" : {
     "vendor" : "io.mintmetrics.mojito",
     "name" : "mojito_exposure",
@@ -9,13 +10,19 @@
   "type" : "object",
   "properties" : {
     "waveId" : {
-      "type" : "string"
+      "description" : "A canonical ID of the test used in cookies and in experiment in reports",
+      "type" : "string",
+      "maxLength" : 255
     },
     "waveName" : {
-      "type" : "string"
+      "description" : "The \"pretty\" name of an experiment for high-level reports usability",
+      "type" : "string",
+      "maxLength" : 255
     },
     "recipe" : {
-      "type" : "string"
+      "description" : "The \"pretty\" name of a recipe that's also used in reports",
+      "type" : "string",
+      "maxLength" : 255
     }
   },
   "additionalProperties" : false

--- a/events/jsonschema/io.mintmetrics.mojito/mojito_exposure/jsonschema/1-0-0
+++ b/events/jsonschema/io.mintmetrics.mojito/mojito_exposure/jsonschema/1-0-0
@@ -10,7 +10,7 @@
   "type" : "object",
   "properties" : {
     "waveId" : {
-      "description" : "A canonical ID of the test used in cookies and in experiment in reports",
+      "description" : "A canonical ID of the test used in cookies and in experiment reports",
       "type" : "string",
       "maxLength" : 255
     },

--- a/events/jsonschema/io.mintmetrics.mojito/mojito_exposure/jsonschema/1-0-0
+++ b/events/jsonschema/io.mintmetrics.mojito/mojito_exposure/jsonschema/1-0-0
@@ -1,6 +1,6 @@
 {
   "$schema" : "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-  "description" : "These events are tracked approximately when users get assigned or bucketed into a test group. We use this to establish the time and group each user is in, so any future conversions can be attributed to the test.",
+  "description" : "Schema for Mojito exposure events",
   "self" : {
     "vendor" : "io.mintmetrics.mojito",
     "name" : "mojito_exposure",


### PR DESCRIPTION
Snowplow schema linting throws an error when the maxLenght attribute is missing. I've added a length based on the mojito create table sql. Also I've added descriptions to the fields and the schema.