### PR TITLE
Add descriptions and maxLength to the failure schema.

### DIFF
--- a/events/jsonschema/io.mintmetrics.mojito/mojito_failure/jsonschema/1-0-0
+++ b/events/jsonschema/io.mintmetrics.mojito/mojito_failure/jsonschema/1-0-0
@@ -1,6 +1,6 @@
 {
   "$schema" : "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
-  "description" : "In complex builds, it's hard to avoid errors firing from experiment variants (such as obscure browsers, products with unusual features or deployments breaking tests mid-way through). Errors can mean the difference between your treatment working or breaking.",
+  "description" : "Schema for a Mojito failure event",
   "self" : {
     "vendor" : "io.mintmetrics.mojito",
     "name" : "mojito_failure",

--- a/events/jsonschema/io.mintmetrics.mojito/mojito_failure/jsonschema/1-0-0
+++ b/events/jsonschema/io.mintmetrics.mojito/mojito_failure/jsonschema/1-0-0
@@ -10,7 +10,7 @@
   "type" : "object",
   "properties" : {
     "waveId" : {
-      "description" : "A canonical ID of the test used in cookies and in experiment in reports",
+      "description" : "A canonical ID of the test used in cookies and in experiment reports",
       "type" : "string",
       "maxLength" : 255
     },

--- a/events/jsonschema/io.mintmetrics.mojito/mojito_failure/jsonschema/1-0-0
+++ b/events/jsonschema/io.mintmetrics.mojito/mojito_failure/jsonschema/1-0-0
@@ -1,5 +1,6 @@
 {
   "$schema" : "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description" : "In complex builds, it's hard to avoid errors firing from experiment variants (such as obscure browsers, products with unusual features or deployments breaking tests mid-way through). Errors can mean the difference between your treatment working or breaking.",
   "self" : {
     "vendor" : "io.mintmetrics.mojito",
     "name" : "mojito_failure",
@@ -9,16 +10,24 @@
   "type" : "object",
   "properties" : {
     "waveId" : {
-      "type" : "string"
+      "description" : "A canonical ID of the test used in cookies and in experiment in reports",
+      "type" : "string",
+      "maxLength" : 255
     },
     "waveName" : {
-      "type" : "string"
+      "description" : "The \"pretty\" name of an experiment for high-level reports usability",
+      "type" : "string",
+      "maxLength" : 255
     },
     "component" : {
-      "type" : "string"
+      "description" : "The recipe name or trigger where the error was emanating from",
+      "type" : "string",
+      "maxLength" : 255
     },
     "error" : {
-      "type" : "string"
+      "description" : "The error message and stack (if available)",
+      "type" : "string",
+      "maxLength" : 1000
     }
   },
   "additionalProperties" : false


### PR DESCRIPTION
Snowplow schema linting throws an error when the maxLength attribute is missing. I've added a length based on the mojito create table sql. Also I've added descriptions to the fields and the schema.